### PR TITLE
FEAT: 자동 폴링으로 실시간 데이터 갱신 (#19)

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-query": "^5.96.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,18 +1,22 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Layout from '@/components/Layout';
 import ProjectListPage from '@/pages/ProjectListPage';
 import ProjectPage from '@/pages/ProjectPage';
+import { queryClient } from '@/lib/queryClient';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<ProjectListPage />} />
-          <Route path="/projects/:id" element={<ProjectPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<ProjectListPage />} />
+            <Route path="/projects/:id" element={<ProjectPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 }
 

--- a/apps/frontend/src/components/AutoSyncIndicator.tsx
+++ b/apps/frontend/src/components/AutoSyncIndicator.tsx
@@ -33,7 +33,7 @@ export default function AutoSyncIndicator({
       <span
         className={`inline-block w-1.5 h-1.5 rounded-full ${
           isSyncing
-            ? 'bg-green-400 animate-pulse'
+            ? 'bg-blue-400 animate-pulse'
             : hasError
               ? 'bg-orange-400'
               : 'bg-green-400'

--- a/apps/frontend/src/components/AutoSyncIndicator.tsx
+++ b/apps/frontend/src/components/AutoSyncIndicator.tsx
@@ -1,0 +1,57 @@
+interface AutoSyncIndicatorProps {
+  isPolling: boolean;
+  isSyncing: boolean;
+  lastSyncAt: Date | null;
+  nextSyncIn: number | null;
+  hasError: boolean;
+}
+
+export default function AutoSyncIndicator({
+  isPolling,
+  isSyncing,
+  lastSyncAt,
+  nextSyncIn,
+  hasError,
+}: AutoSyncIndicatorProps) {
+  if (!isPolling) return null;
+
+  const formatTime = (seconds: number): string => {
+    if (seconds >= 60) return `${Math.floor(seconds / 60)}m`;
+    return `${seconds}s`;
+  };
+
+  const formatLastSync = (date: Date): string => {
+    const diff = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (diff < 60) return 'just now';
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return `${Math.floor(diff / 3600)}h ago`;
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-gray-400">
+      {/* 상태 dot */}
+      <span
+        className={`inline-block w-1.5 h-1.5 rounded-full ${
+          isSyncing
+            ? 'bg-green-400 animate-pulse'
+            : hasError
+              ? 'bg-orange-400'
+              : 'bg-green-400'
+        }`}
+      />
+
+      {/* 상태 텍스트 */}
+      {isSyncing ? (
+        <span>Syncing...</span>
+      ) : hasError && nextSyncIn != null ? (
+        <span>Retry in {formatTime(nextSyncIn)}</span>
+      ) : nextSyncIn != null ? (
+        <span>Next sync in {formatTime(nextSyncIn)}</span>
+      ) : lastSyncAt ? (
+        <span>Synced {formatLastSync(lastSyncAt)}</span>
+      ) : (
+        <span>Auto-sync</span>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/useAutoSync.ts
+++ b/apps/frontend/src/hooks/useAutoSync.ts
@@ -2,13 +2,13 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { useSyncMutation } from './useSyncMutation';
 import { useSyncSettings } from './useSyncSettings';
 
-const MAX_INTERVAL = 1800; // 최대 30분 (초)
+const MAX_INTERVAL = 1800;
 
 export interface AutoSyncState {
   isPolling: boolean;
   isSyncing: boolean;
   lastSyncAt: Date | null;
-  nextSyncIn: number | null; // 다음 sync까지 남은 초
+  nextSyncIn: number | null;
   hasError: boolean;
   consecutiveErrors: number;
 }
@@ -20,43 +20,56 @@ export function useAutoSync(projectId: number) {
   const [lastSyncAt, setLastSyncAt] = useState<Date | null>(null);
   const [nextSyncIn, setNextSyncIn] = useState<number | null>(null);
   const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+  const [isVisible, setIsVisible] = useState(true);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const isVisibleRef = useRef(true);
-  const isMountedRef = useRef(true);
 
-  // 현재 유효 interval 계산 (에러 백오프 적용)
-  const getEffectiveInterval = useCallback(() => {
-    const base = settings.interval;
-    if (consecutiveErrors === 0) return base;
-    return Math.min(base * Math.pow(2, consecutiveErrors), MAX_INTERVAL);
-  }, [settings.interval, consecutiveErrors]);
+  // ref로 안정화 (무한 루프 방지)
+  const syncMutateRef = useRef(syncMutation.mutate);
+  syncMutateRef.current = syncMutation.mutate;
+  const isPendingRef = useRef(syncMutation.isPending);
+  isPendingRef.current = syncMutation.isPending;
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const consecutiveErrorsRef = useRef(consecutiveErrors);
+  consecutiveErrorsRef.current = consecutiveErrors;
 
-  // sync 실행 함수
+  const clearTimers = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    timerRef.current = null;
+    countdownRef.current = null;
+  }, []);
+
+  // sync 실행 (의존성 없음 - ref 사용)
   const doSync = useCallback(() => {
-    if (syncMutation.isPending || !isMountedRef.current) return;
+    if (isPendingRef.current) return;
 
-    syncMutation.mutate(undefined, {
+    syncMutateRef.current(undefined, {
       onSuccess: () => {
-        if (!isMountedRef.current) return;
         setConsecutiveErrors(0);
         setLastSyncAt(new Date());
       },
       onError: () => {
-        if (!isMountedRef.current) return;
         setConsecutiveErrors((prev) => prev + 1);
       },
     });
-  }, [syncMutation]);
+  }, []);
 
-  // 타이머 스케줄
+  // 유효 interval 계산
+  const getEffectiveInterval = useCallback(() => {
+    const base = settingsRef.current.interval;
+    const errors = consecutiveErrorsRef.current;
+    if (errors === 0) return base;
+    return Math.min(base * Math.pow(2, errors), MAX_INTERVAL);
+  }, []);
+
+  // 타이머 스케줄 (의존성 없음 - ref 사용)
   const scheduleNext = useCallback(() => {
-    // 기존 타이머 클리어
-    if (timerRef.current) clearTimeout(timerRef.current);
-    if (countdownRef.current) clearInterval(countdownRef.current);
+    clearTimers();
 
-    if (!settings.auto || !isVisibleRef.current) {
+    if (!settingsRef.current.auto) {
       setNextSyncIn(null);
       return;
     }
@@ -64,7 +77,6 @@ export function useAutoSync(projectId: number) {
     const intervalSec = getEffectiveInterval();
     setNextSyncIn(intervalSec);
 
-    // 카운트다운
     countdownRef.current = setInterval(() => {
       setNextSyncIn((prev) => {
         if (prev === null || prev <= 1) return null;
@@ -72,35 +84,36 @@ export function useAutoSync(projectId: number) {
       });
     }, 1000);
 
-    // 다음 sync 예약
     timerRef.current = setTimeout(() => {
       if (countdownRef.current) clearInterval(countdownRef.current);
       doSync();
     }, intervalSec * 1000);
-  }, [settings.auto, getEffectiveInterval, doSync]);
+  }, [clearTimers, getEffectiveInterval, doSync]);
 
-  // sync 완료/실패 후 다음 스케줄
+  // sync 완료/실패 후 다음 스케줄 (status 실제 변경만 감지)
+  const prevStatusRef = useRef(syncMutation.status);
   useEffect(() => {
-    if (!syncMutation.isPending && settings.auto && isVisibleRef.current) {
+    if (prevStatusRef.current === syncMutation.status) return;
+    prevStatusRef.current = syncMutation.status;
+
+    if (!syncMutation.isPending && settingsRef.current.auto && isVisible) {
       scheduleNext();
     }
-  }, [syncMutation.isPending, syncMutation.status, scheduleNext, settings.auto]);
+  }, [syncMutation.status, syncMutation.isPending, isVisible, scheduleNext]);
 
   // 탭 비활성 처리
   useEffect(() => {
     const handleVisibility = () => {
-      isVisibleRef.current = document.visibilityState === 'visible';
+      const visible = document.visibilityState === 'visible';
+      setIsVisible(visible);
 
-      if (!isVisibleRef.current) {
-        // hidden: 타이머 정지
-        if (timerRef.current) clearTimeout(timerRef.current);
-        if (countdownRef.current) clearInterval(countdownRef.current);
+      if (!visible) {
+        clearTimers();
         setNextSyncIn(null);
       } else {
-        // visible: 즉시 sync + 타이머 재시작
-        if (settings.onFocus && settings.auto) {
+        if (settingsRef.current.onFocus && settingsRef.current.auto) {
           doSync();
-        } else if (settings.auto) {
+        } else if (settingsRef.current.auto) {
           scheduleNext();
         }
       }
@@ -108,34 +121,20 @@ export function useAutoSync(projectId: number) {
 
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
-  }, [settings.onFocus, settings.auto, doSync, scheduleNext]);
+  }, [doSync, scheduleNext, clearTimers]);
 
-  // 초기 타이머 시작
+  // cleanup on unmount / projectId change
   useEffect(() => {
-    if (settings.auto && projectId) {
-      scheduleNext();
-    }
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (countdownRef.current) clearInterval(countdownRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId]); // projectId 변경 시만 재시작
-
-  // cleanup
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
+    return () => clearTimers();
+  }, [projectId, clearTimers]);
 
   return {
-    isPolling: settings.auto && isVisibleRef.current,
+    syncMutation,
+    isPolling: settings.auto && isVisible,
     isSyncing: syncMutation.isPending,
     lastSyncAt,
     nextSyncIn,
     hasError: consecutiveErrors > 0,
     consecutiveErrors,
-  } satisfies AutoSyncState;
+  };
 }

--- a/apps/frontend/src/hooks/useAutoSync.ts
+++ b/apps/frontend/src/hooks/useAutoSync.ts
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useSyncMutation } from './useSyncMutation';
+import { useSyncSettings } from './useSyncSettings';
+
+const MAX_INTERVAL = 1800; // 최대 30분 (초)
+
+export interface AutoSyncState {
+  isPolling: boolean;
+  isSyncing: boolean;
+  lastSyncAt: Date | null;
+  nextSyncIn: number | null; // 다음 sync까지 남은 초
+  hasError: boolean;
+  consecutiveErrors: number;
+}
+
+export function useAutoSync(projectId: number) {
+  const { settings } = useSyncSettings();
+  const syncMutation = useSyncMutation(projectId);
+
+  const [lastSyncAt, setLastSyncAt] = useState<Date | null>(null);
+  const [nextSyncIn, setNextSyncIn] = useState<number | null>(null);
+  const [consecutiveErrors, setConsecutiveErrors] = useState(0);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isVisibleRef = useRef(true);
+  const isMountedRef = useRef(true);
+
+  // 현재 유효 interval 계산 (에러 백오프 적용)
+  const getEffectiveInterval = useCallback(() => {
+    const base = settings.interval;
+    if (consecutiveErrors === 0) return base;
+    return Math.min(base * Math.pow(2, consecutiveErrors), MAX_INTERVAL);
+  }, [settings.interval, consecutiveErrors]);
+
+  // sync 실행 함수
+  const doSync = useCallback(() => {
+    if (syncMutation.isPending || !isMountedRef.current) return;
+
+    syncMutation.mutate(undefined, {
+      onSuccess: () => {
+        if (!isMountedRef.current) return;
+        setConsecutiveErrors(0);
+        setLastSyncAt(new Date());
+      },
+      onError: () => {
+        if (!isMountedRef.current) return;
+        setConsecutiveErrors((prev) => prev + 1);
+      },
+    });
+  }, [syncMutation]);
+
+  // 타이머 스케줄
+  const scheduleNext = useCallback(() => {
+    // 기존 타이머 클리어
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+
+    if (!settings.auto || !isVisibleRef.current) {
+      setNextSyncIn(null);
+      return;
+    }
+
+    const intervalSec = getEffectiveInterval();
+    setNextSyncIn(intervalSec);
+
+    // 카운트다운
+    countdownRef.current = setInterval(() => {
+      setNextSyncIn((prev) => {
+        if (prev === null || prev <= 1) return null;
+        return prev - 1;
+      });
+    }, 1000);
+
+    // 다음 sync 예약
+    timerRef.current = setTimeout(() => {
+      if (countdownRef.current) clearInterval(countdownRef.current);
+      doSync();
+    }, intervalSec * 1000);
+  }, [settings.auto, getEffectiveInterval, doSync]);
+
+  // sync 완료/실패 후 다음 스케줄
+  useEffect(() => {
+    if (!syncMutation.isPending && settings.auto && isVisibleRef.current) {
+      scheduleNext();
+    }
+  }, [syncMutation.isPending, syncMutation.status, scheduleNext, settings.auto]);
+
+  // 탭 비활성 처리
+  useEffect(() => {
+    const handleVisibility = () => {
+      isVisibleRef.current = document.visibilityState === 'visible';
+
+      if (!isVisibleRef.current) {
+        // hidden: 타이머 정지
+        if (timerRef.current) clearTimeout(timerRef.current);
+        if (countdownRef.current) clearInterval(countdownRef.current);
+        setNextSyncIn(null);
+      } else {
+        // visible: 즉시 sync + 타이머 재시작
+        if (settings.onFocus && settings.auto) {
+          doSync();
+        } else if (settings.auto) {
+          scheduleNext();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [settings.onFocus, settings.auto, doSync, scheduleNext]);
+
+  // 초기 타이머 시작
+  useEffect(() => {
+    if (settings.auto && projectId) {
+      scheduleNext();
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (countdownRef.current) clearInterval(countdownRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]); // projectId 변경 시만 재시작
+
+  // cleanup
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return {
+    isPolling: settings.auto && isVisibleRef.current,
+    isSyncing: syncMutation.isPending,
+    lastSyncAt,
+    nextSyncIn,
+    hasError: consecutiveErrors > 0,
+    consecutiveErrors,
+  } satisfies AutoSyncState;
+}

--- a/apps/frontend/src/hooks/useProjectListQuery.ts
+++ b/apps/frontend/src/hooks/useProjectListQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+import type { Project } from '@/types';
+
+export function useProjectListQuery() {
+  return useQuery({
+    queryKey: queryKeys.projects.all,
+    queryFn: () => apiGet<Project[]>('/projects'),
+  });
+}

--- a/apps/frontend/src/hooks/useProjectQueries.ts
+++ b/apps/frontend/src/hooks/useProjectQueries.ts
@@ -30,11 +30,9 @@ export function useMilestonesQuery(projectId: number) {
 export function useStatusColumnsQuery(projectId: number) {
   return useQuery({
     queryKey: queryKeys.statusColumns.all(projectId),
-    queryFn: () =>
-      apiGet<string[]>(`/sync/status-options?projectId=${projectId}`).catch(
-        () => [] as string[],
-      ),
+    queryFn: () => apiGet<string[]>(`/sync/status-options?projectId=${projectId}`),
     enabled: !!projectId,
+    retry: 0,
   });
 }
 

--- a/apps/frontend/src/hooks/useProjectQueries.ts
+++ b/apps/frontend/src/hooks/useProjectQueries.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+import type { Project, Task, Milestone } from '@/types';
+
+export function useProjectQuery(projectId: number) {
+  return useQuery({
+    queryKey: queryKeys.projects.detail(projectId),
+    queryFn: () => apiGet<Project>(`/projects/${projectId}`),
+    enabled: !!projectId,
+  });
+}
+
+export function useTasksQuery(projectId: number) {
+  return useQuery({
+    queryKey: queryKeys.tasks.all(projectId),
+    queryFn: () => apiGet<Task[]>(`/tasks?projectId=${projectId}`),
+    enabled: !!projectId,
+  });
+}
+
+export function useMilestonesQuery(projectId: number) {
+  return useQuery({
+    queryKey: queryKeys.milestones.all(projectId),
+    queryFn: () => apiGet<Milestone[]>(`/milestones?projectId=${projectId}`),
+    enabled: !!projectId,
+  });
+}
+
+export function useStatusColumnsQuery(projectId: number) {
+  return useQuery({
+    queryKey: queryKeys.statusColumns.all(projectId),
+    queryFn: () =>
+      apiGet<string[]>(`/sync/status-options?projectId=${projectId}`).catch(
+        () => [] as string[],
+      ),
+    enabled: !!projectId,
+  });
+}
+
+/** 편의 훅: ProjectPage에서 필요한 4개 쿼리를 한번에 호출 */
+export function useProjectPageData(projectId: number) {
+  const projectQuery = useProjectQuery(projectId);
+  const tasksQuery = useTasksQuery(projectId);
+  const milestonesQuery = useMilestonesQuery(projectId);
+  const statusColumnsQuery = useStatusColumnsQuery(projectId);
+
+  return {
+    project: projectQuery.data ?? null,
+    tasks: tasksQuery.data ?? [],
+    milestones: milestonesQuery.data ?? [],
+    statusColumns: statusColumnsQuery.data ?? [],
+    isLoading:
+      projectQuery.isLoading ||
+      tasksQuery.isLoading ||
+      milestonesQuery.isLoading,
+    error:
+      projectQuery.error || tasksQuery.error || milestonesQuery.error,
+  };
+}

--- a/apps/frontend/src/hooks/useSyncMutation.ts
+++ b/apps/frontend/src/hooks/useSyncMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiPost } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+
+export function useSyncMutation(projectId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiPost(`/sync/pull?projectId=${projectId}`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tasks.all(projectId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.milestones.all(projectId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.statusColumns.all(projectId),
+      });
+    },
+  });
+}

--- a/apps/frontend/src/hooks/useSyncSettings.ts
+++ b/apps/frontend/src/hooks/useSyncSettings.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'gpm-sync-settings';
+
+export interface SyncSettings {
+  interval: number; // 초 단위, 기본 300 (5분)
+  auto: boolean; // 자동 폴링 활성화, 기본 true
+  onFocus: boolean; // 탭 복귀 시 즉시 동기화, 기본 true
+}
+
+const DEFAULTS: SyncSettings = {
+  interval: 300,
+  auto: true,
+  onFocus: true,
+};
+
+function loadSettings(): SyncSettings {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return DEFAULTS;
+    return { ...DEFAULTS, ...JSON.parse(stored) };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function useSyncSettings() {
+  const [settings, setSettings] = useState<SyncSettings>(loadSettings);
+
+  const updateSettings = useCallback((partial: Partial<SyncSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...partial };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  return { settings, updateSettings };
+}

--- a/apps/frontend/src/hooks/useSyncSettings.ts
+++ b/apps/frontend/src/hooks/useSyncSettings.ts
@@ -1,11 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useSyncExternalStore, useCallback } from 'react';
 
 const STORAGE_KEY = 'gpm-sync-settings';
 
 export interface SyncSettings {
-  interval: number; // 초 단위, 기본 300 (5분)
-  auto: boolean; // 자동 폴링 활성화, 기본 true
-  onFocus: boolean; // 탭 복귀 시 즉시 동기화, 기본 true
+  interval: number;
+  auto: boolean;
+  onFocus: boolean;
 }
 
 const DEFAULTS: SyncSettings = {
@@ -14,7 +14,7 @@ const DEFAULTS: SyncSettings = {
   onFocus: true,
 };
 
-function loadSettings(): SyncSettings {
+function loadFromStorage(): SyncSettings {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return DEFAULTS;
@@ -24,15 +24,25 @@ function loadSettings(): SyncSettings {
   }
 }
 
+let currentSettings: SyncSettings = loadFromStorage();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function getSnapshot(): SyncSettings {
+  return currentSettings;
+}
+
 export function useSyncSettings() {
-  const [settings, setSettings] = useState<SyncSettings>(loadSettings);
+  const settings = useSyncExternalStore(subscribe, getSnapshot);
 
   const updateSettings = useCallback((partial: Partial<SyncSettings>) => {
-    setSettings((prev) => {
-      const next = { ...prev, ...partial };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-      return next;
-    });
+    currentSettings = { ...currentSettings, ...partial };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(currentSettings));
+    listeners.forEach((l) => l());
   }, []);
 
   return { settings, updateSettings };

--- a/apps/frontend/src/hooks/useTaskStatusMutation.ts
+++ b/apps/frontend/src/hooks/useTaskStatusMutation.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiPatch } from '@/api/client';
+import { queryKeys } from '@/lib/queryKeys';
+import type { Task } from '@/types';
+
+export function useTaskStatusMutation(projectId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      taskId,
+      status,
+    }: {
+      taskId: number;
+      status: string;
+    }) => apiPatch(`/tasks/${taskId}?projectId=${projectId}`, { status }),
+    onMutate: async ({ taskId, status }) => {
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.tasks.all(projectId),
+      });
+      const previous = queryClient.getQueryData<Task[]>(
+        queryKeys.tasks.all(projectId),
+      );
+      queryClient.setQueryData<Task[]>(
+        queryKeys.tasks.all(projectId),
+        (old) => old?.map((t) => (t.id === taskId ? { ...t, status } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.tasks.all(projectId),
+          context.previous,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tasks.all(projectId),
+      });
+    },
+  });
+}

--- a/apps/frontend/src/lib/queryClient.ts
+++ b/apps/frontend/src/lib/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30 * 1000,
+      gcTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: true,
+      retry: 1,
+    },
+  },
+});

--- a/apps/frontend/src/lib/queryKeys.ts
+++ b/apps/frontend/src/lib/queryKeys.ts
@@ -1,0 +1,16 @@
+export const queryKeys = {
+  projects: {
+    all: ['projects'] as const,
+    detail: (id: number) => ['projects', id] as const,
+  },
+  tasks: {
+    all: (projectId: number) => ['tasks', { projectId }] as const,
+    detail: (id: number) => ['tasks', id] as const,
+  },
+  milestones: {
+    all: (projectId: number) => ['milestones', { projectId }] as const,
+  },
+  statusColumns: {
+    all: (projectId: number) => ['statusColumns', { projectId }] as const,
+  },
+} as const;

--- a/apps/frontend/src/pages/ProjectListPage.tsx
+++ b/apps/frontend/src/pages/ProjectListPage.tsx
@@ -1,20 +1,10 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { apiGet, Project } from '@/api/client';
+import { useProjectListQuery } from '@/hooks/useProjectListQuery';
 
 export default function ProjectListPage() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: projects = [], isLoading, error } = useProjectListQuery();
 
-  useEffect(() => {
-    apiGet<Project[]>('/projects')
-      .then(setProjects)
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[50vh]">
         <p className="text-gray-500">Loading...</p>
@@ -27,7 +17,7 @@ export default function ProjectListPage() {
       <div className="flex items-center justify-center min-h-[50vh]">
         <div className="text-center">
           <p className="text-red-500 mb-2">Failed to load projects</p>
-          <p className="text-gray-400 text-sm">{error}</p>
+          <p className="text-gray-400 text-sm">{error?.message ?? 'Unknown error'}</p>
         </div>
       </div>
     );

--- a/apps/frontend/src/pages/ProjectPage.tsx
+++ b/apps/frontend/src/pages/ProjectPage.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import type { Task, Milestone } from '@/types';
 import { useProjectPageData } from '@/hooks/useProjectQueries';
-import { useSyncMutation } from '@/hooks/useSyncMutation';
 import { useAutoSync } from '@/hooks/useAutoSync';
 import { useTaskStatusMutation } from '@/hooks/useTaskStatusMutation';
 import AutoSyncIndicator from '@/components/AutoSyncIndicator';
@@ -18,8 +17,7 @@ export default function ProjectPage() {
   // 서버 상태 (React Query)
   const { project, tasks, milestones, statusColumns, isLoading, error } =
     useProjectPageData(projectId);
-  const syncMutation = useSyncMutation(projectId);
-  const autoSync = useAutoSync(projectId);
+  const { syncMutation, ...autoSync } = useAutoSync(projectId);
   const statusMutation = useTaskStatusMutation(projectId);
 
   // UI 상태 (useState)
@@ -27,6 +25,14 @@ export default function ProjectPage() {
   const [milestoneFilter, setMilestoneFilter] = useState<number | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [selectedMilestone, setSelectedMilestone] = useState<Milestone | null>(null);
+
+  if (!id || Number.isNaN(projectId)) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <p className="text-red-500">Invalid project ID</p>
+      </div>
+    );
+  }
 
   // 이벤트 핸들러
   const handleSync = () => {

--- a/apps/frontend/src/pages/ProjectPage.tsx
+++ b/apps/frontend/src/pages/ProjectPage.tsx
@@ -3,7 +3,9 @@ import { useParams, Link } from 'react-router-dom';
 import type { Task, Milestone } from '@/types';
 import { useProjectPageData } from '@/hooks/useProjectQueries';
 import { useSyncMutation } from '@/hooks/useSyncMutation';
+import { useAutoSync } from '@/hooks/useAutoSync';
 import { useTaskStatusMutation } from '@/hooks/useTaskStatusMutation';
+import AutoSyncIndicator from '@/components/AutoSyncIndicator';
 import MilestoneSummary from '@/components/MilestoneSummary';
 import KanbanBoard from '@/components/KanbanBoard';
 import TaskDetailPanel from '@/components/TaskDetailPanel';
@@ -17,6 +19,7 @@ export default function ProjectPage() {
   const { project, tasks, milestones, statusColumns, isLoading, error } =
     useProjectPageData(projectId);
   const syncMutation = useSyncMutation(projectId);
+  const autoSync = useAutoSync(projectId);
   const statusMutation = useTaskStatusMutation(projectId);
 
   // UI 상태 (useState)
@@ -90,12 +93,20 @@ export default function ProjectPage() {
             Project #{project?.projectNumber}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={handleSync}
-          disabled={syncMutation.isPending}
-          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
+        <div className="flex items-center gap-3">
+          <AutoSyncIndicator
+            isPolling={autoSync.isPolling}
+            isSyncing={autoSync.isSyncing}
+            lastSyncAt={autoSync.lastSyncAt}
+            nextSyncIn={autoSync.nextSyncIn}
+            hasError={autoSync.hasError}
+          />
+          <button
+            type="button"
+            onClick={handleSync}
+            disabled={syncMutation.isPending || autoSync.isSyncing}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
           {syncMutation.isPending ? (
             <>
               <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
@@ -112,7 +123,8 @@ export default function ProjectPage() {
               Sync
             </>
           )}
-        </button>
+          </button>
+        </div>
       </div>
 
       {/* Milestone Summary */}

--- a/apps/frontend/src/pages/ProjectPage.tsx
+++ b/apps/frontend/src/pages/ProjectPage.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { apiGet, apiPost, apiPatch } from '@/api/client';
-import type { Project, Task, Milestone } from '@/types';
+import type { Task, Milestone } from '@/types';
+import { useProjectPageData } from '@/hooks/useProjectQueries';
+import { useSyncMutation } from '@/hooks/useSyncMutation';
+import { useTaskStatusMutation } from '@/hooks/useTaskStatusMutation';
 import MilestoneSummary from '@/components/MilestoneSummary';
 import KanbanBoard from '@/components/KanbanBoard';
 import TaskDetailPanel from '@/components/TaskDetailPanel';
@@ -9,77 +11,31 @@ import MilestoneDetailPanel from '@/components/MilestoneDetailPanel';
 
 export default function ProjectPage() {
   const { id } = useParams<{ id: string }>();
+  const projectId = Number(id);
 
-  const [project, setProject] = useState<Project | null>(null);
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [milestones, setMilestones] = useState<Milestone[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // 서버 상태 (React Query)
+  const { project, tasks, milestones, statusColumns, isLoading, error } =
+    useProjectPageData(projectId);
+  const syncMutation = useSyncMutation(projectId);
+  const statusMutation = useTaskStatusMutation(projectId);
+
+  // UI 상태 (useState)
   const [toast, setToast] = useState<string | null>(null);
-  const [syncing, setSyncing] = useState(false);
-  const [statusColumns, setStatusColumns] = useState<string[]>([]);
   const [milestoneFilter, setMilestoneFilter] = useState<number | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [selectedMilestone, setSelectedMilestone] = useState<Milestone | null>(null);
 
-  useEffect(() => {
-    if (!id) return;
-
-    const load = async () => {
-      try {
-        const [projectData, taskData, milestoneData] = await Promise.all([
-          apiGet<Project>(`/projects/${id}`),
-          apiGet<Task[]>(`/tasks?projectId=${id}`),
-          apiGet<Milestone[]>(`/milestones?projectId=${id}`),
-        ]);
-        setProject(projectData);
-        setTasks(taskData);
-        setMilestones(milestoneData);
-
-        const columns = await apiGet<string[]>(`/sync/status-options?projectId=${id}`).catch(() => [] as string[]);
-        setStatusColumns(columns);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load project');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    load();
-  }, [id]);
-
-  const handleSync = async () => {
-    if (!id || syncing) return;
-
-    setSyncing(true);
-    try {
-      await apiPost(`/sync/pull?projectId=${id}`, {});
-      const [taskData, milestoneData, columns] = await Promise.all([
-        apiGet<Task[]>(`/tasks?projectId=${id}`),
-        apiGet<Milestone[]>(`/milestones?projectId=${id}`),
-        apiGet<string[]>(`/sync/status-options?projectId=${id}&force=true`),
-      ]);
-      setTasks(taskData);
-      setMilestones(milestoneData);
-      setStatusColumns(columns);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Sync failed');
-    } finally {
-      setSyncing(false);
-    }
+  // 이벤트 핸들러
+  const handleSync = () => {
+    if (syncMutation.isPending) return;
+    syncMutation.mutate();
   };
 
   const handleStatusChange = (taskId: number, newStatus: string) => {
-    const previousTasks = tasks;
-    setTasks((prev) =>
-      prev.map((t) => (t.id === taskId ? { ...t, status: newStatus } : t)),
+    statusMutation.mutate(
+      { taskId, status: newStatus },
+      { onError: (err) => setToast(`Failed to update status: ${err.message}`) },
     );
-
-    apiPatch(`/tasks/${taskId}?projectId=${id}`, { status: newStatus })
-      .catch((err) => {
-        setTasks(previousTasks);
-        setToast(`Failed to update status: ${err instanceof Error ? err.message : 'Unknown error'}`);
-      });
   };
 
   const handleMilestoneClick = (milestone: Milestone) => {
@@ -95,7 +51,7 @@ export default function ProjectPage() {
     setSelectedTask(task);
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[50vh]">
         <p className="text-gray-500">Loading...</p>
@@ -108,7 +64,7 @@ export default function ProjectPage() {
       <div className="flex items-center justify-center min-h-[50vh]">
         <div className="text-center">
           <p className="text-red-500 mb-2">Failed to load project</p>
-          <p className="text-gray-400 text-sm">{error}</p>
+          <p className="text-gray-400 text-sm">{error.message ?? 'Unknown error'}</p>
         </div>
       </div>
     );
@@ -137,10 +93,10 @@ export default function ProjectPage() {
         <button
           type="button"
           onClick={handleSync}
-          disabled={syncing}
+          disabled={syncMutation.isPending}
           className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-500 rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {syncing ? (
+          {syncMutation.isPending ? (
             <>
               <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,6 +603,7 @@ __metadata:
     "@dnd-kit/utilities": ^3.2.2
     "@tailwindcss/typography": ^0.5.19
     "@tailwindcss/vite": ^4.0.0
+    "@tanstack/react-query": ^5.96.1
     "@types/react": ^19.0.0
     "@types/react-dom": ^19.0.0
     "@vitejs/plugin-react": ^4.0.0
@@ -1603,6 +1604,24 @@ __metadata:
   peerDependencies:
     vite: ^5.2.0 || ^6 || ^7 || ^8
   checksum: 1390282177a7cdfc7550b529b376a029e9d52ac9ab67028eb5e506b861b00270470666fd713e3f02289330fb48fde8ed5e68718f4463b121408195396be9d702
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-core@npm:5.96.1":
+  version: 5.96.1
+  resolution: "@tanstack/query-core@npm:5.96.1"
+  checksum: 5b2bb124bb80e5431b85551a6eb93b5d3cf73158f43962d846768a5d63e95fa5a1393f333704571a5d0b76cf58608e605f234b1535416676c04c3b83f944af20
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.96.1":
+  version: 5.96.1
+  resolution: "@tanstack/react-query@npm:5.96.1"
+  dependencies:
+    "@tanstack/query-core": 5.96.1
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 89061420e92564d0fb4a03785ebd3ebff562e4ee0c828fb91f1cdc58683a76f9ee64695df8213ad4bb67fb99104de48a38da3cffbed26d2ed88e981da52b8c59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- TanStack Query v5 도입 및 기존 fetch+useState 패턴을 React Query로 전면 마이그레이션
- 5분 간격 자동 폴링으로 GitHub 데이터 실시간 갱신 (에러 시 2배 백오프, 최대 30분)
- 탭 비활성 시 폴링 자동 중지, 복귀 시 즉시 동기화
- AutoSyncIndicator로 폴링 상태를 subtle하게 표시

## Changes
- **Phase A**: @tanstack/react-query v5 설치, QueryClient 설정 (staleTime 30s, gcTime 5m), queryKeys 팩토리
- **Phase B**: ProjectListPage를 React Query로 마이그레이션
- **Phase C**: ProjectPage를 React Query로 마이그레이션 (207줄→163줄), useSyncMutation + useTaskStatusMutation(낙관적 업데이트)
- **Phase D**: useAutoSync 훅 (타이머 기반 폴링, 에러 백오프, visibility API), useSyncSettings (localStorage 설정), AutoSyncIndicator 컴포넌트

## Test plan
- [ ] `yarn build` 성공 확인
- [ ] ProjectListPage 진입 시 프로젝트 목록 로딩 정상
- [ ] ProjectPage 진입 시 데이터 로딩 + Sync 버튼 수동 동작 정상
- [ ] 자동 폴링 주기 실행 확인 (콘솔 또는 네트워크 탭)
- [ ] 탭 전환 후 복귀 시 즉시 sync 실행
- [ ] 칸반 DnD 상태 변경 시 낙관적 업데이트 + 서버 반영

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)