### PR TITLE
FEAT: 프로젝트별 고유 prefix + GitHub Issue/PR 번호 표시

### DIFF
--- a/apps/backend/src/middleware/project-context.middleware.ts
+++ b/apps/backend/src/middleware/project-context.middleware.ts
@@ -1,12 +1,13 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import { Request, Response, NextFunction } from 'express';
+import { Response, NextFunction } from 'express';
+import { RequestWithProject } from '../types/request';
 import { ProjectService } from '../modules/project/project.service';
 
 @Injectable()
 export class ProjectContextMiddleware implements NestMiddleware {
   constructor(private readonly projectService: ProjectService) {}
 
-  async use(req: Request, res: Response, next: NextFunction) {
+  async use(req: RequestWithProject, res: Response, next: NextFunction) {
     const owner = req.headers['x-gpm-owner'] as string;
     const projectNumber = Number(req.headers['x-gpm-project-number']);
 
@@ -22,7 +23,7 @@ export class ProjectContextMiddleware implements NestMiddleware {
       });
       return;
     }
-    (req as any).project = project;
+    req.project = project;
     next();
   }
 }

--- a/apps/backend/src/modules/project/project.controller.ts
+++ b/apps/backend/src/modules/project/project.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, ParseIntPipe, NotFoundException, Req } from '@nestjs/common';
-import { Request } from 'express';
+import { RequestWithProject } from '../../types/request';
 import { ProjectService } from './project.service';
 
 @Controller('projects')
@@ -12,8 +12,8 @@ export class ProjectController {
   }
 
   @Get('current')
-  async findCurrent(@Req() req: Request) {
-    const project = (req as any).project;
+  async findCurrent(@Req() req: RequestWithProject) {
+    const project = req.project;
     if (!project) throw new NotFoundException('No project context. Send X-GPM-Owner and X-GPM-Project-Number headers.');
     return project;
   }

--- a/apps/backend/src/modules/project/project.controller.ts
+++ b/apps/backend/src/modules/project/project.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Param, ParseIntPipe, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, NotFoundException, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { ProjectService } from './project.service';
 
 @Controller('projects')
@@ -8,6 +9,13 @@ export class ProjectController {
   @Get()
   async findAll() {
     return this.projectService.findAll();
+  }
+
+  @Get('current')
+  async findCurrent(@Req() req: Request) {
+    const project = (req as any).project;
+    if (!project) throw new NotFoundException('No project context. Send X-GPM-Owner and X-GPM-Project-Number headers.');
+    return project;
   }
 
   @Get(':id')

--- a/apps/backend/src/modules/project/project.entity.ts
+++ b/apps/backend/src/modules/project/project.entity.ts
@@ -42,6 +42,9 @@ export class Project {
   @Column({ name: 'status_options_fetched_at', type: 'datetime', nullable: true })
   statusOptionsFetchedAt: Date | null;
 
+  @Column({ unique: true, nullable: true })
+  prefix: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/apps/backend/src/modules/project/project.service.ts
+++ b/apps/backend/src/modules/project/project.service.ts
@@ -28,9 +28,10 @@ export class ProjectService {
     if (existing) {
       if (extra) {
         Object.assign(existing, extra);
-        return this.projectRepo.save(existing);
+        return this.projectRepo.save(existing)
+          .then((saved) => this.ensurePrefix(saved));
       }
-      return existing;
+      return this.ensurePrefix(existing);
     }
 
     const prefix = await this.generatePrefix(extra?.repo ?? null, owner);
@@ -88,7 +89,11 @@ export class ProjectService {
     return repo.substring(0, 3).toUpperCase();
   }
 
-  private async generateRandomPrefix(): Promise<string> {
+  private async generateRandomPrefix(depth = 0): Promise<string> {
+    if (depth >= 10) {
+      return `P${Date.now().toString(36).slice(-5).toUpperCase()}`;
+    }
+
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     let prefix = '';
     for (let i = 0; i < 6; i++) {
@@ -97,7 +102,7 @@ export class ProjectService {
 
     const isDuplicate = await this.projectRepo.findOneBy({ prefix })
       .then((found) => !!found);
-    if (isDuplicate) return this.generateRandomPrefix();
+    if (isDuplicate) return this.generateRandomPrefix(depth + 1);
     return prefix;
   }
 }

--- a/apps/backend/src/modules/project/project.service.ts
+++ b/apps/backend/src/modules/project/project.service.ts
@@ -15,7 +15,8 @@ export class ProjectService {
   }
 
   async findById(id: number): Promise<Project | null> {
-    return this.projectRepo.findOneBy({ id });
+    return this.projectRepo.findOneBy({ id })
+      .then((project) => project ? this.ensurePrefix(project) : null);
   }
 
   async findOrCreate(
@@ -32,21 +33,71 @@ export class ProjectService {
       return existing;
     }
 
+    const prefix = await this.generatePrefix(extra?.repo ?? null, owner);
     const project = this.projectRepo.create({
       owner,
       projectNumber,
       projectUrl: extra?.projectUrl ?? '',
       ownerType: extra?.ownerType ?? 'organization',
       repo: extra?.repo ?? undefined,
+      prefix,
     });
     return this.projectRepo.save(project);
   }
 
   async findByOwnerAndNumber(owner: string, projectNumber: number): Promise<Project | null> {
-    return this.projectRepo.findOneBy({ owner, projectNumber });
+    return this.projectRepo.findOneBy({ owner, projectNumber })
+      .then((project) => project ? this.ensurePrefix(project) : null);
   }
 
   async save(project: Project): Promise<Project> {
     return this.projectRepo.save(project);
+  }
+
+  private async ensurePrefix(project: Project): Promise<Project> {
+    if (project.prefix) return project;
+    project.prefix = await this.generatePrefix(project.repo, project.owner);
+    return this.projectRepo.save(project);
+  }
+
+  private async generatePrefix(repo: string | null, owner: string): Promise<string> {
+    const candidate = repo
+      ? this.extractAbbreviation(repo)
+      : owner.substring(0, 3).toUpperCase();
+
+    const isUnique = await this.projectRepo.findOneBy({ prefix: candidate })
+      .then((found) => !found);
+    if (isUnique) return candidate;
+
+    const MAX_RETRIES = 5;
+    for (let i = 0; i < MAX_RETRIES; i++) {
+      const suffix = Math.random().toString(36).substring(2, 4).toUpperCase();
+      const withSuffix = `${candidate}${suffix}`;
+      const isDuplicate = await this.projectRepo.findOneBy({ prefix: withSuffix })
+        .then((found) => !!found);
+      if (!isDuplicate) return withSuffix;
+    }
+
+    return this.generateRandomPrefix();
+  }
+
+  private extractAbbreviation(repo: string): string {
+    const words = repo.split(/[-_]/);
+    const abbreviation = words.map((w) => w.charAt(0).toUpperCase()).join('');
+    if (abbreviation.length >= 2) return abbreviation;
+    return repo.substring(0, 3).toUpperCase();
+  }
+
+  private async generateRandomPrefix(): Promise<string> {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let prefix = '';
+    for (let i = 0; i < 6; i++) {
+      prefix += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+
+    const isDuplicate = await this.projectRepo.findOneBy({ prefix })
+      .then((found) => !!found);
+    if (isDuplicate) return this.generateRandomPrefix();
+    return prefix;
   }
 }

--- a/apps/backend/src/modules/sync/github.service.ts
+++ b/apps/backend/src/modules/sync/github.service.ts
@@ -7,6 +7,7 @@ interface ProjectItem {
   content: {
     __typename: string;
     title?: string;
+    number?: number;
     body?: string;
     updatedAt?: string;
     headRefName?: string;
@@ -107,6 +108,7 @@ export class GitHubService {
                   }
                   ... on Issue {
                     title
+                    number
                     body
                     updatedAt
                     author { login avatarUrl }
@@ -127,6 +129,7 @@ export class GitHubService {
                   }
                   ... on PullRequest {
                     title
+                    number
                     body
                     updatedAt
                     headRefName

--- a/apps/backend/src/modules/sync/sync.service.ts
+++ b/apps/backend/src/modules/sync/sync.service.ts
@@ -158,6 +158,7 @@ export class SyncService {
         existing.authorLogin = authorLogin;
         existing.authorAvatarUrl = authorAvatarUrl;
         existing.milestoneId = milestoneId;
+        existing.githubNumber = item.content?.number ?? existing.githubNumber;
         existing.githubUpdatedAt = item.content.updatedAt ? new Date(item.content.updatedAt) : existing.githubUpdatedAt;
         existing.syncedAt = new Date();
         existing.isDirty = false;
@@ -177,6 +178,7 @@ export class SyncService {
         task.authorLogin = authorLogin;
         task.authorAvatarUrl = authorAvatarUrl;
         task.milestoneId = milestoneId;
+        task.githubNumber = item.content?.number ?? null;
         if (item.content.updatedAt) {
           task.githubCreatedAt = new Date(item.content.updatedAt);
           task.githubUpdatedAt = new Date(item.content.updatedAt);

--- a/apps/backend/src/modules/task/task.entity.ts
+++ b/apps/backend/src/modules/task/task.entity.ts
@@ -76,6 +76,9 @@ export class Task {
   @Column({ name: 'author_avatar_url', type: 'varchar', nullable: true })
   authorAvatarUrl: string | null;
 
+  @Column({ name: 'github_number', type: 'integer', nullable: true })
+  githubNumber: number | null;
+
   @Column({ name: 'milestone_id', nullable: true })
   milestoneId: number | null;
 

--- a/apps/backend/src/types/request.ts
+++ b/apps/backend/src/types/request.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express';
+import { Project } from '../modules/project/project.entity';
+
+export interface RequestWithProject extends Request {
+  project?: Project;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -50,7 +50,11 @@ taskCmd
   .option('--limit <n>', 'Limit results', '20')
   .action(async (options) => {
     try {
-      const tasks = await apiRequest<any[]>('/tasks');
+      const [tasks, project] = await Promise.all([
+        apiRequest<any[]>('/tasks'),
+        apiRequest<any>('/projects/current').catch(() => null),
+      ]);
+      const prefix = project?.prefix;
       if (options.json) {
         console.log(JSON.stringify(tasks, null, 2));
       } else {
@@ -58,10 +62,12 @@ taskCmd
           console.log('No tasks found.');
           return;
         }
-        console.log('ID\tStatus\t\tTitle');
-        console.log('--\t------\t\t-----');
+        console.log('ID\t\tGH#\tStatus\t\tTitle');
+        console.log('--\t\t---\t------\t\t-----');
         tasks.slice(0, Number(options.limit)).forEach((t: any) => {
-          console.log(`${t.id}\t${t.status}\t\t${t.title}`);
+          const id = prefix ? `${prefix}-${t.id}` : `#${t.id}`;
+          const gh = t.githubNumber ? `#${t.githubNumber}` : '-';
+          console.log(`${id}\t\t${gh}\t${t.status}\t\t${t.title}`);
         });
       }
     } catch (err) {
@@ -76,11 +82,17 @@ taskCmd
   .option('--json', 'Output as JSON')
   .action(async (id, options) => {
     try {
-      const task = await apiRequest<any>(`/tasks/${id}`);
+      const [task, project] = await Promise.all([
+        apiRequest<any>(`/tasks/${id}`),
+        apiRequest<any>('/projects/current').catch(() => null),
+      ]);
+      const prefix = project?.prefix;
       if (options.json) {
         console.log(JSON.stringify(task, null, 2));
       } else {
-        console.log(`#${task.id} ${task.title}`);
+        const idDisplay = prefix ? `${prefix}-${task.id}` : `#${task.id}`;
+        const ghDisplay = task.githubNumber ? ` (GitHub #${task.githubNumber})` : '';
+        console.log(`${idDisplay}${ghDisplay} ${task.title}`);
         console.log(`Status: ${task.status}`);
         console.log(`Type: ${task.contentType}`);
         if (task.body) console.log(`\n${task.body}`);
@@ -106,7 +118,10 @@ taskCmd
       if (options.json) {
         console.log(JSON.stringify(task, null, 2));
       } else {
-        console.log(`✓ Task #${task.id} created: ${task.title}`);
+        const project = await apiRequest<any>('/projects/current').catch(() => null);
+        const prefix = project?.prefix;
+        const idDisplay = prefix ? `${prefix}-${task.id}` : `#${task.id}`;
+        console.log(`✓ Task ${idDisplay} created: ${task.title}`);
       }
     } catch (err) {
       console.error(`✗ ${(err as Error).message}`);
@@ -157,11 +172,14 @@ taskCmd
   .description('Quick status change')
   .action(async (id, status) => {
     try {
-      await apiRequest(`/tasks/${id}`, {
+      const task = await apiRequest<any>(`/tasks/${id}`, {
         method: 'PATCH',
         body: { status },
       });
-      console.log(`✓ Task #${id} status → "${status}"`);
+      const project = await apiRequest<any>('/projects/current').catch(() => null);
+      const prefix = project?.prefix;
+      const idDisplay = prefix ? `${prefix}-${task.id}` : `#${task.id}`;
+      console.log(`✓ Task ${idDisplay} status → "${status}"`);
     } catch (err) {
       console.error(`✗ ${(err as Error).message}`);
       process.exit(1);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -146,7 +146,10 @@ taskCmd
       if (json) {
         console.log(JSON.stringify(task, null, 2));
       } else {
-        console.log(`✓ Task #${task.id} updated`);
+        const project = await apiRequest<any>('/projects/current').catch(() => null);
+        const prefix = project?.prefix;
+        const idDisplay = prefix ? `${prefix}-${task.id}` : `#${task.id}`;
+        console.log(`✓ Task ${idDisplay} updated`);
       }
     } catch (err) {
       console.error(`✗ ${(err as Error).message}`);
@@ -160,7 +163,10 @@ taskCmd
   .action(async (id) => {
     try {
       await apiRequest(`/tasks/${id}`, { method: 'DELETE' });
-      console.log(`✓ Task #${id} deleted`);
+      const project = await apiRequest<any>('/projects/current').catch(() => null);
+      const prefix = project?.prefix;
+      const idDisplay = prefix ? `${prefix}-${id}` : `#${id}`;
+      console.log(`✓ Task ${idDisplay} deleted`);
     } catch (err) {
       console.error(`✗ ${(err as Error).message}`);
       process.exit(1);

--- a/apps/frontend/src/components/KanbanBoard.tsx
+++ b/apps/frontend/src/components/KanbanBoard.tsx
@@ -13,6 +13,7 @@ interface KanbanBoardProps {
   onMilestoneFilterChange?: (milestoneId: number | null) => void;
   onTaskClick: (task: Task) => void;
   onStatusChange: (taskId: number, newStatus: string) => void;
+  prefix?: string | null;
 }
 
 type SortOption = 'newest' | 'oldest' | 'priority' | 'title';
@@ -43,7 +44,7 @@ function sortTasks(tasks: Task[], option: SortOption): Task[] {
   }
 }
 
-export default function KanbanBoard({ tasks, columns, milestones, activeMilestoneId, onMilestoneFilterChange, onTaskClick, onStatusChange }: KanbanBoardProps) {
+export default function KanbanBoard({ tasks, columns, milestones, activeMilestoneId, onMilestoneFilterChange, onTaskClick, onStatusChange, prefix }: KanbanBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [sortOption, setSortOption] = useState<SortOption>('newest');
   const sensors = useSensors(
@@ -146,11 +147,12 @@ export default function KanbanBoard({ tasks, columns, milestones, activeMileston
             title={column}
             tasks={grouped[column]}
             onTaskClick={onTaskClick}
+            prefix={prefix}
           />
         ))}
       </div>
       <DragOverlay>
-        {activeTask ? <TaskCard task={activeTask} onClick={() => {}} isDragOverlay /> : null}
+        {activeTask ? <TaskCard task={activeTask} onClick={() => {}} isDragOverlay prefix={prefix} /> : null}
       </DragOverlay>
     </DndContext>
   );

--- a/apps/frontend/src/components/KanbanColumn.tsx
+++ b/apps/frontend/src/components/KanbanColumn.tsx
@@ -6,6 +6,7 @@ interface KanbanColumnProps {
   title: string;
   tasks: Task[];
   onTaskClick: (task: Task) => void;
+  prefix?: string | null;
 }
 
 const columnHeaderColor: Record<string, string> = {
@@ -14,7 +15,7 @@ const columnHeaderColor: Record<string, string> = {
   Done: 'bg-green-500',
 };
 
-export default function KanbanColumn({ title, tasks, onTaskClick }: KanbanColumnProps) {
+export default function KanbanColumn({ title, tasks, onTaskClick, prefix }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: title });
   const dotColor = columnHeaderColor[title] ?? 'bg-gray-400';
 
@@ -32,7 +33,7 @@ export default function KanbanColumn({ title, tasks, onTaskClick }: KanbanColumn
           <p className="text-xs text-gray-400 text-center py-4">No tasks</p>
         )}
         {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} onClick={() => onTaskClick(task)} />
+          <TaskCard key={task.id} task={task} onClick={() => onTaskClick(task)} prefix={prefix} />
         ))}
       </div>
     </div>

--- a/apps/frontend/src/components/TaskCard.tsx
+++ b/apps/frontend/src/components/TaskCard.tsx
@@ -19,6 +19,7 @@ interface TaskCardProps {
   task: Task;
   onClick: () => void;
   isDragOverlay?: boolean;
+  prefix?: string | null;
 }
 
 const contentTypeBadgeColor: Record<string, string> = {
@@ -27,7 +28,7 @@ const contentTypeBadgeColor: Record<string, string> = {
   PullRequest: 'bg-green-100 text-green-700',
 };
 
-export default function TaskCard({ task, onClick, isDragOverlay }: TaskCardProps) {
+export default function TaskCard({ task, onClick, isDragOverlay, prefix }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: task.id,
     disabled: isDragOverlay,
@@ -55,7 +56,12 @@ export default function TaskCard({ task, onClick, isDragOverlay }: TaskCardProps
       className={`w-full text-left bg-white border border-gray-200 rounded-lg p-3 hover:shadow-md hover:border-gray-300 transition-all cursor-pointer ${isDragging ? 'opacity-50' : ''}`}
     >
       <div className="flex items-center gap-2 mb-1">
-        <span className="text-xs text-gray-400 font-mono">#{task.id}</span>
+        <span className="text-xs text-gray-400 font-mono">
+          {prefix ? `${prefix}-${task.id}` : `#${task.id}`}
+        </span>
+        {task.githubNumber && (
+          <span className="text-xs text-gray-500 font-mono">#{task.githubNumber}</span>
+        )}
         <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${badgeClass}`}>
           {task.contentType}
         </span>

--- a/apps/frontend/src/components/TaskDetailPanel.tsx
+++ b/apps/frontend/src/components/TaskDetailPanel.tsx
@@ -7,6 +7,7 @@ import { normalizeAssignees } from '@/types';
 interface TaskDetailPanelProps {
   task: Task | null;
   onClose: () => void;
+  prefix?: string | null;
 }
 
 const statusBadgeColor: Record<string, string> = {
@@ -32,7 +33,7 @@ function formatDate(dateStr: string): string {
   });
 }
 
-export default function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
+export default function TaskDetailPanel({ task, onClose, prefix }: TaskDetailPanelProps) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -68,7 +69,12 @@ export default function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps)
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
-            <span className="text-sm text-gray-400 font-mono">#{task.id}</span>
+            <span className="text-sm text-gray-400 font-mono">
+              {prefix ? `${prefix}-${task.id}` : `#${task.id}`}
+            </span>
+            {task.githubNumber && (
+              <span className="text-sm text-gray-500 font-mono">#{task.githubNumber}</span>
+            )}
             <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${contentTypeClass}`}>
               {task.contentType}
             </span>

--- a/apps/frontend/src/pages/ProjectPage.tsx
+++ b/apps/frontend/src/pages/ProjectPage.tsx
@@ -154,11 +154,12 @@ export default function ProjectPage() {
           onMilestoneFilterChange={setMilestoneFilter}
           onTaskClick={handleTaskClick}
           onStatusChange={handleStatusChange}
+          prefix={project?.prefix}
         />
       </div>
 
       {/* Detail Panels */}
-      <TaskDetailPanel task={selectedTask} onClose={() => setSelectedTask(null)} />
+      <TaskDetailPanel task={selectedTask} onClose={() => setSelectedTask(null)} prefix={project?.prefix} />
       <MilestoneDetailPanel
         milestone={selectedMilestone}
         tasks={tasks}

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -5,6 +5,7 @@ export interface Project {
   repo: string | null;
   projectNumber: number;
   projectUrl: string;
+  prefix: string | null;
   createdAt: string;
 }
 
@@ -16,6 +17,7 @@ export interface Assignee {
 export interface Task {
   id: number;
   projectId: number;
+  githubNumber?: number | null;
   title: string;
   body?: string;
   status: string;

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -41,6 +41,7 @@ GitHub Project V2의 Item 필드를 로컬 SQLite 테이블 컬럼으로 매핑�
 | `project_number` | INTEGER | NOT NULL | GitHub Project 번호 |
 | `project_url` | TEXT | NOT NULL | GitHub Project URL |
 | `github_project_id` | TEXT | | GitHub Project GraphQL node ID (sync 후 채움, nullable) |
+| `prefix` | TEXT | UNIQUE | 프로젝트 고유 prefix (자동 생성, 예: GPAM) |
 | `created_at` | DATETIME | NOT NULL, DEFAULT CURRENT_TIMESTAMP | 로컬 생성 시각 |
 | `updated_at` | DATETIME | NOT NULL, DEFAULT CURRENT_TIMESTAMP | 로컬 수정 시각 |
 
@@ -53,6 +54,7 @@ CREATE TABLE projects (
     project_number INTEGER NOT NULL,
     project_url TEXT NOT NULL,
     github_project_id TEXT,
+    prefix TEXT UNIQUE,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(owner, project_number)
@@ -82,6 +84,7 @@ GitHub Project Item과 매핑되는 태스크 데이터를 저장합니다.
 | `branch` | TEXT | | 연결된 Git 브랜치명 (nullable) |
 | `author_login` | TEXT | | Issue/PR 작성자 GitHub 로그인 (nullable) |
 | `author_avatar_url` | TEXT | | Issue/PR 작성자 프로필 이미지 URL (nullable) |
+| `github_number` | INTEGER | | GitHub Issue/PR 번호 (DraftIssue는 null) |
 | `created_at` | DATETIME | NOT NULL, DEFAULT CURRENT_TIMESTAMP | 로컬 생성 시각 |
 | `updated_at` | DATETIME | NOT NULL, DEFAULT CURRENT_TIMESTAMP | 로컬 수정 시각 |
 | `github_created_at` | DATETIME | | GitHub 생성 시각 |
@@ -104,6 +107,7 @@ CREATE TABLE tasks (
     branch TEXT,
     author_login TEXT,
     author_avatar_url TEXT,
+    github_number INTEGER,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     github_created_at DATETIME,


### PR DESCRIPTION
## Summary

- Project Entity에 `prefix` 컬럼 추가 — repo명에서 약자를 자동 생성하고, 중복 시 랜덤 suffix 부여
- Task Entity에 `githubNumber` 컬럼 추가 — GitHub Issue/PR 번호를 저장
- GraphQL Issue/PR fragment에 `number` 필드 추가하여 Sync 시 `githubNumber` 자동 매핑
- FE `TaskCard` / `TaskDetailPanel`에 `PREFIX-ID` 형식과 GitHub 번호 함께 표시
- CLI `task list` / `show` / `create` / `status` 명령에 prefix + GitHub 번호 출력
- `GET /projects/current` API 엔드포인트 추가
- `docs/spec/data-model.md` 스펙 업데이트

## Changed Files

| 영역 | 파일 |
|------|------|
| Backend - Entity | `project.entity.ts`, `task.entity.ts` |
| Backend - Service | `project.service.ts`, `sync.service.ts` |
| Backend - Controller | `project.controller.ts` |
| Backend - GitHub | `github.service.ts` |
| CLI | `apps/cli/src/index.ts` |
| Frontend | `KanbanBoard.tsx`, `KanbanColumn.tsx`, `TaskCard.tsx`, `TaskDetailPanel.tsx`, `ProjectPage.tsx`, `types/index.ts` |
| Docs | `docs/spec/data-model.md` |

## Test plan

- [ ] `gpm sync` 실행 후 각 태스크에 `PREFIX-ID` 및 GitHub 번호가 정상 표시되는지 확인
- [ ] 동일 repo 약자가 충돌하는 경우 랜덤 suffix가 붙어 prefix가 유니크하게 생성되는지 확인
- [ ] `GET /projects/current` 응답에 `prefix` 필드 포함 여부 확인
- [ ] 칸반 보드 TaskCard 및 TaskDetailPanel에 `PREFIX-ID` + GitHub 번호 렌더링 확인
- [ ] CLI `gpm task list` 출력에 prefix 및 GitHub 번호 컬럼 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)